### PR TITLE
feat(elk): added elk stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 ### dotenv file
 .env
 /**.env
+
+# ignore any generated log file ending with .log extension
+*.log

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ System sprzedaży biletów umożliwiający użytkownikom kupowanie i odsprzedawa
 - [ ] Proces budowania powinien wytwarzać gotowy do wdrożenia artefakt: plik JAR  
 - [x] Należy dostarczyć pliki: Dockerfile oraz Docker Compose, zawierające kompletne środowisko uruchomieniowe  
 - [x] Usługa powinna zawierać persystencję. Baza danych w odrębnym Dockerfile, połączona poprzez compose  
-- [ ] Usługa powinna być monitorowana np. za pomocą ELK. Środowisko monitorujące w osobnym Dockerfile, połączone przez compose 
+- [x] Usługa powinna być monitorowana np. za pomocą ELK. Środowisko monitorujące w osobnym Dockerfile, połączone przez compose 
 - [ ] Usługa powinna korzystać z jakiegoś zewnętrznego API 
 - [x] Usługa powinna być zabezpieczona przynajmniej na podstawowym poziomie. Logowanie basic auth lub autoryzacja Google  
 - [x] Usługa zawiera minimum 3 poziomy uprawnień użytkowników  

--- a/elk/docker-compose.yml
+++ b/elk/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.5
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - cluster.name=passgo-backend-logs
+      - node.name=node-1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - elk
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.17.5
+    container_name: logstash
+    depends_on:
+      - elasticsearch
+    ports:
+      - "5044:5044"
+    volumes:
+#      - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
+      - ./logstash/pipeline:/usr/share/logstash/pipeline
+      - ../logging/passgo.log:/usr/share/logstash/data/passgo-backend.log
+    networks:
+      - elk
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.17.5
+    container_name: kibana
+    depends_on:
+      - elasticsearch
+    ports:
+      - "5601:5601"
+    networks:
+      - elk
+
+volumes:
+  esdata:
+    name: esdata
+
+networks:
+  elk:
+    driver: bridge

--- a/elk/logstash/config/logstash.yml
+++ b/elk/logstash/config/logstash.yml
@@ -1,0 +1,3 @@
+http.host: '0.0.0.0'
+path.config: /usr/share/logstash/pipeline
+xpack.monitoring.enabled: false

--- a/elk/logstash/pipeline/logstash.conf
+++ b/elk/logstash/pipeline/logstash.conf
@@ -1,0 +1,15 @@
+input {
+ file {
+    path => "/usr/share/logstash/data/passgo-backend.log"
+    start_position => "beginning"
+    sincedb_path => "/dev/null"
+    codec => json
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "passgo-backend-logs-index"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
 			<artifactId>javase</artifactId>
 			<version>3.5.3</version>
 		</dependency>
+		<dependency>
+			<groupId>net.logstash.logback</groupId>
+			<artifactId>logstash-logback-encoder</artifactId>
+			<version>7.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+
+    <appender name="STASH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logging/passgo.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>./logging/archive/passgo-arch-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>2</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <logger name="org.hibernate.type" level="ALL" />
+    <logger name="org.hibernate.SQL" level="DEBUG" />
+
+    <root level="INFO">
+        <appender-ref ref="STASH" />
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
- created docker-compose for elk stack
- backend logs to `logging/passgo.log` and console

(you don't have to create any folder structure, e.g. folders for storing logs. Folders will be created automatically)
Starting elk:
1. navigate to`/elk` folder
2. then execute command: `docker compose up -d`